### PR TITLE
Add Windows platform support and fix memory safety issues

### DIFF
--- a/src/api/process.zig
+++ b/src/api/process.zig
@@ -149,9 +149,13 @@ pub fn register(eng: *engine.Engine) void {
     const arch_str = getArchString();
     eng.setProperty(process, "arch", c.JS_NewString(eng.context, arch_str.ptr));
 
-    // PID (using libc)
-    const pid = std.c.getpid();
-    eng.setProperty(process, "pid", c.JS_NewInt32(eng.context, @intCast(pid)));
+    // PID (platform-specific)
+    // Use i64 to safely represent Windows DWORD (u32) without overflow
+    const pid: i64 = if (builtin.os.tag == .windows)
+        @intCast(std.os.windows.GetCurrentProcessId())
+    else
+        @intCast(std.c.getpid());
+    eng.setProperty(process, "pid", c.JS_NewInt64(eng.context, pid));
 
     // Environment variables
     eng.setProperty(process, "env", buildEnvObject(eng.context));

--- a/src/main.zig
+++ b/src/main.zig
@@ -63,7 +63,12 @@ pub fn main() u8 {
     }
 
     // Collect all arguments for process.argv
-    var args = std.process.args();
+    var args = std.process.argsWithAllocator(std.heap.page_allocator) catch {
+        print("Failed to get process arguments\n", .{});
+        return 1;
+    };
+    defer args.deinit();
+
     var argv_list: std.ArrayListUnmanaged([:0]const u8) = .{};
     defer argv_list.deinit(std.heap.page_allocator);
 
@@ -293,7 +298,12 @@ fn runEmbeddedCode(code: []const u8) u8 {
     event_loop.setGlobalEventLoop(&loop);
 
     // Set process.argv from actual args
-    var args = std.process.args();
+    var args = std.process.argsWithAllocator(std.heap.page_allocator) catch {
+        print("Failed to get process arguments\n", .{});
+        return 1;
+    };
+    defer args.deinit();
+
     var argv_list: std.ArrayListUnmanaged([:0]const u8) = .{};
     defer argv_list.deinit(std.heap.page_allocator);
 


### PR DESCRIPTION
- Add Windows support for process args (argsWithAllocator), PID (GetCurrentProcessId), and I/O poller (stub)
- Fix PID type from i32 to i64 to prevent overflow with Windows DWORDs (might remove if no needed)
- Fix event buffer allocation to use max of platform event and IoEvent sizes, preventing buffer overflow on Linux

Also 

As Ordu University clubs, we are organizing a technology winter camp called WinterBytes between January 30 and February 1, 2026. Focusing on software and cybersecurity, this program will give participants the opportunity to get to know the industry closely through training sessions, workshops, and conferences, as well as an exhibition on the last day.

We would like to invite you to speak at the event in the field of software. Our training days will take place on January 30 and 31. We leave the choice of topic entirely up to you, as long as it fits within the software framework. If you are able to participate, we kindly request that you submit the topic you wish to present by January 6.

We would be delighted to have you join us.
If you share your thoughts with us, we will gladly complete the necessary planning.


Contact: winterbytes@ordu.dev